### PR TITLE
Remove extra output from cluster test causing integration test failures

### DIFF
--- a/internal/provider/files/cluster_test/outputs.tf
+++ b/internal/provider/files/cluster_test/outputs.tf
@@ -28,7 +28,3 @@ output "cluster_compute_fleet_resource" {
 output "cluster_data_source" {
   value = data.pcluster_cluster.test
 }
-
-output "cluster_list_data_source" {
-  value = data.pcluster_list_clusters.test
-}


### PR DESCRIPTION
### Description of changes
The cluster list output is empty before creating the test cluster, this causes a drift in the outputs when running an apply immediately after creating a cluster. This output is unused so it can be removed.

### Tests
* make test

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
