### PR TITLE
[Test] Fix issue with TestEnd2EndCluster causing the test to fail when the test uses a custom cluster name

### DIFF
--- a/internal/provider/cluster_test.go
+++ b/internal/provider/cluster_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestEnd2EndCluster(t *testing.T) {
-	clusterName := "test-cluster"
+	clusterName := defaultClusterName
 
 	configVariables := config.Variables{
 		"cluster_name": config.StringVariable(clusterName),
@@ -94,6 +94,7 @@ func TestEnd2EndCluster(t *testing.T) {
 	if name, ok := os.LookupEnv("TEST_CLUSTER_NAME"); ok {
 		configVariables["cluster_name"] = config.StringVariable(name)
 		configUpdateVariables["cluster_name"] = config.StringVariable(name)
+		clusterName = name
 	}
 
 	t.Parallel()

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -1,6 +1,7 @@
 package provider
 
 const (
-	defaultRegion = "us-east-1"
-	defaultAz     = "us-east-1a"
+	defaultRegion      = "us-east-1"
+	defaultAz          = "us-east-1a"
+	defaultClusterName = "test-cluster"
 )


### PR DESCRIPTION

### Description of changes
Fix issue with TestEnd2EndCluster causing the test to fail when the test uses a custom cluster name set by envar TEST_CLUSTER_NAME. In particular, the tests was creating the cluster with the custom name, as expected, but then it was expecting the cluster name to be equal to the default one.


### Tests
* TestEnd2EndCluster succeeded.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
