### PR TITLE
[Test] Make end2end tests workflow able to run test in AWS account

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -37,7 +37,7 @@ jobs:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"
           TEST_AVAILABILITY_ZONE: "us-east-1a"
-          TEST_CLUSTER_NAME: "test-cluster"
+          TEST_CLUSTER_NAME: "test-cluster-github"
           TEST_ROLE: ${{ secrets.ACTION_E2E_TESTS_ROLE }}
           TEST_ENDPOINT: ${{ secrets.ACTION_E2E_TESTS_ENDPOINT }}
         run: go test ./... -v -run="^TestEnd2End" -timeout 60m

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,9 +1,9 @@
 # This workflow validates PRs and pushes with code checks, unit tests and end-to-end tests.
-name: End To End Tests 
+name: End To End Tests
 
 on:
   push:
-    branches: 
+    branches:
       - main
 jobs:
   end-to-end-tests:
@@ -36,6 +36,7 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"
+          TEST_AVAILABILITY_ZONE: "us-east-1a"
           TEST_CLUSTER_NAME: "test-cluster"
           TEST_ROLE: ${{ secrets.ACTION_E2E_TESTS_ROLE }}
           TEST_ENDPOINT: ${{ secrets.ACTION_E2E_TESTS_ENDPOINT }}

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   end-to-end-tests:
     name: End To End Tests
@@ -33,6 +38,12 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ACTION_E2E_TESTS_ROLE }}
+          role-session-name: GitHub_TerraformProviderAwsParallelCluster_End2EndTests
       - env:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -37,8 +37,8 @@ jobs:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"
           TEST_AVAILABILITY_ZONE: "us-east-1a"
+          TEST_PCAPI_STACK_NAME: "ParallelCluster"
+          TEST_USE_USER_ROLE: "true"
           TEST_CLUSTER_NAME: "test-cluster-github"
-          TEST_ROLE: ${{ secrets.ACTION_E2E_TESTS_ROLE }}
-          TEST_ENDPOINT: ${{ secrets.ACTION_E2E_TESTS_ENDPOINT }}
         run: go test ./... -v -run="^TestEnd2End" -timeout 60m
         timeout-minutes: 65

--- a/tools/tests/test-env.sh
+++ b/tools/tests/test-env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Variables you can set in your local test environment
+#
+# TEST_REGION:                    AWS region;
+#                                 This is the region where the tests will run.
+#                                 Default is AWS_DEFAULT_REGION or us-east-1 if AWS_DEFAULT_REGION is not set.
+#
+# TEST_AVAILABILITY_ZONE:         AWS availability zone;
+#                                 This is the availability zone where the tests will run.
+#                                 Default is us-east-1a.
+#
+# TEST_PCAPI_STACK_NAME:          CloudFormation stack name;
+#                                 This is the name of the existing ParallelCluster API stack that tests will use.
+#                                 Default is ParallelCluster.
+#
+# TEST_USE_USER_ROLE:             [true|false];
+#                                 If true, the tests will use the user role ParallelClusterApiUserRole returned by the ParallelCluster API.
+#                                 Default is false.
+#
+# TEST_CLUSTER_NAME:              [Cluster name];
+#                                 This is the name of the cluster that tests will create.
+#                                 Default is test-cluster.
+
+export TEST_REGION="us-east-1"
+export TEST_AVAILABILITY_ZONE="us-east-1a"
+export TEST_PCAPI_STACK_NAME="ParallelCluster"
+export TEST_USE_USER_ROLE="true"
+export TEST_CLUSTER_NAME="test-cluster-$(whoami)"


### PR DESCRIPTION
### Description of changes
Make end2end tests workflow able to run test in AWS account.

### Tests
* envars tested by manually launching the tests from local environment.
* creds retrieval will be tested after merge as it's longer to setup a test for it than iterating on the live workflow.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
