### PR TITLE
[Infrastructure] Increase max session duration from 1h to 2h for roles assumed by GitHub to execute integration tests.

### DIFF
--- a/infrastructure/github-env.yml
+++ b/infrastructure/github-env.yml
@@ -14,7 +14,7 @@ Parameters:
     Description: Name of the GitHub repository for the module.
     Type: String
     Default: terraform-aws-parallelcluster
-    
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -52,6 +52,7 @@ Resources:
                 token.actions.githubusercontent.com:sub: !Sub repo:${Organization}/${ProviderRepository}:ref:refs/heads/main
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess  # TODO Add all the necessary permissions to launch e2e tests.
+      MaxSessionDuration: 7200
 
   ModuleE2ETestExecutionRole:
     Type: AWS::IAM::Role
@@ -69,6 +70,7 @@ Resources:
                 token.actions.githubusercontent.com:sub: !Sub repo:${Organization}/${ModuleRepository}:ref:refs/heads/main
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess  # TODO Add all the necessary permissions to launch e2e tests.
+      MaxSessionDuration: 7200
 
 Outputs:
   ProviderE2ETestExecutionRole:


### PR DESCRIPTION
### Description of changes
Increase max session duration from 1h to 2h for roles assumed by GitHub to execute integration tests.
Max integ test duration is now 1h, so we want to provide more.

### Tests
* CFN template deployed in test account.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
