### PR TITLE
[Build] Add makefile targets to execute cluster and image e2e test separately

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,6 +62,12 @@ test:
 test_end2end:
 	TF_ACC=1 go test ./... -v -run="^TestEnd2End" $(TESTARGS) -timeout 120m
 
+test_end2end_cluster:
+	TF_ACC=1 go test ./... -v -run="^TestEnd2EndCluster" $(TESTARGS) -timeout 120m
+
+test_end2end_image:
+	TF_ACC=1 go test ./... -v -run="^TestEnd2EndImage" $(TESTARGS) -timeout 120m
+
 test_unit:
 	TF_ACC=1 go test ./... -v -run="^TestUnit" $(TESTARGS) -timeout 10m -cover
 


### PR DESCRIPTION
### Description of changes
Add makefile targets to execute cluster and image e2e test separately.
This separation is useful to do local validations, especially considering that the build image test is expected to fail due to a known issue in CloudFormation causing stack deletion failure.

### Tests
* New targets execute the expected tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
