### PR TITLE
[Test] Add missing test envar TEST_IMAGE_NAME to set name of the AMI created by tests 

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -54,5 +54,6 @@ jobs:
           TEST_PCAPI_STACK_NAME: "ParallelCluster"
           TEST_USE_USER_ROLE: "true"
           TEST_CLUSTER_NAME: "test-cluster-github"
+          TEST_IMAGE_NAME: "test-image-github"
         run: go test ./... -v -run="^TestEnd2End" -timeout 60m
         timeout-minutes: 65

--- a/tools/tests/test-env.sh
+++ b/tools/tests/test-env.sh
@@ -21,9 +21,14 @@
 # TEST_CLUSTER_NAME:              [Cluster name];
 #                                 This is the name of the cluster that tests will create.
 #                                 Default is test-cluster.
+#
+# TEST_IMAGE_NAME:                [Image name];
+#                                 This is the name of the AMI that tests will create.
+#                                 Default is test-image.
 
 export TEST_REGION="us-east-1"
 export TEST_AVAILABILITY_ZONE="us-east-1a"
 export TEST_PCAPI_STACK_NAME="ParallelCluster"
 export TEST_USE_USER_ROLE="true"
 export TEST_CLUSTER_NAME="test-cluster-$(whoami)"
+export TEST_IMAGE_NAME="test-image-$(whoami)"


### PR DESCRIPTION
### Description of changes
Add missing test envar TEST_IMAGE_NAME to set name of the AMI created by tests 

### Tests
* Used to run e2e test locally and verified that the ami name is used.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
