### PR TITLE
[Infra] Add policy to run end2end tests.

### DIFF
--- a/infrastructure/github-env.yml
+++ b/infrastructure/github-env.yml
@@ -51,7 +51,7 @@ Resources:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
                 token.actions.githubusercontent.com:sub: !Sub repo:${Organization}/${ProviderRepository}:ref:refs/heads/main
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess  # TODO Add all the necessary permissions to launch e2e tests.
+        - !Ref E2ETestExecutionPolicy
       MaxSessionDuration: 7200
 
   ModuleE2ETestExecutionRole:
@@ -69,8 +69,39 @@ Resources:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
                 token.actions.githubusercontent.com:sub: !Sub repo:${Organization}/${ModuleRepository}:ref:refs/heads/main
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess  # TODO Add all the necessary permissions to launch e2e tests.
+        - !Ref E2ETestExecutionPolicy
       MaxSessionDuration: 7200
+
+  E2ETestExecutionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Permissions to run end-to-end tests.
+      ManagedPolicyName: E2ETestExecutionPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/PCAPIUserRole-*
+            Sid: AssumePCAPIUserRole
+          - Effect: Allow
+            Action:
+              - ec2:DescribeVpcs
+              - ec2:DescribeVpcAttribute
+              - ec2:DescribeSubnets
+              - ec2:DescribeSecurityGroups
+              - ec2:AuthorizeSecurityGroupEgress
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupEgress
+              - ec2:DescribeSecurityGroupRules
+            Resource: '*'
+            Sid: EC2
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource: !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/*
+            Sid: CloudFormation
 
 Outputs:
   ProviderE2ETestExecutionRole:


### PR DESCRIPTION
### Description of changes
Added IAM managed policy to run end2end tests.
The permissions are those required to execute e2e tests in their simplified form, as per https://github.com/aws-tf/terraform-provider-aws-parallelcluster/pull/110.

### Tests
* Executed e2e tests for clyster creation: succeeded
* Executed e2e tests for image creation: failed due to image stack deletion failure, which is a known issue on CFN side not related to this change.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
