### PR TITLE
[Test] Improvements to the GitHub workflow that runs end2end tests for the provider

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,5 +1,5 @@
 # This workflow validates PRs and pushes with code checks, unit tests and end-to-end tests.
-name: End To End Tests
+name: E2E Tests
 
 on:
   push:
@@ -15,28 +15,22 @@ permissions:
 
 jobs:
   end-to-end-tests:
-    name: End To End Tests
+    name: E2E Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        name:
-          - End To End Tests with Go 1.22.0 and Terraform 1.6.6
-          - End To End Tests with Go 1.21.7 and Terraform 1.5.7
-        include:
-          - name: End To End Tests with Go 1.22.0 and Terraform 1.6.6
-            go: 1.22.0
-            terraform: 1.6.6
-          - name: End To End Tests with Go 1.21.7 and Terraform 1.5.7
-            go: 1.21.7
-            terraform: 1.5.7
+        test_target: [test_end2end_cluster, test_end2end_image]
+        go: [1.22.0]
+        terraform: [1.6.6]
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ matrix.terraform }}
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.terraform }}
@@ -47,13 +41,16 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.ACTION_E2E_TESTS_ROLE }}
           role-session-name: GitHub_TerraformProviderAwsParallelCluster_End2EndTests
-      - env:
+      - name: Generate Test ID
+        run: echo "TEST_ID=$(date +'%Y%m%d-%H%M%S-%s')" >> $GITHUB_ENV
+      - name: Execute Tests (${{ matrix.test_target }})
+        env:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"
           TEST_AVAILABILITY_ZONE: "us-east-1a"
           TEST_PCAPI_STACK_NAME: "ParallelCluster"
           TEST_USE_USER_ROLE: "true"
-          TEST_CLUSTER_NAME: "test-cluster-github"
-          TEST_IMAGE_NAME: "test-image-github"
-        run: go test ./... -v -run="^TestEnd2End" -timeout 60m
-        timeout-minutes: 65
+          TEST_CLUSTER_NAME: "test-cluster-github-${{ env.TEST_ID }}"
+          TEST_IMAGE_NAME: "test-image-github-${{ env.TEST_ID }}"
+        run: make ${{ matrix.test_target }}
+        timeout-minutes: 120

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tfplan
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfvars
+errored.tfstate
 
 # Openapi Generator
 .travis.yml


### PR DESCRIPTION
### Description of changes
Improvements to the GitHub workflow that runs end2end tests for the provider.
In particular:
1. Use a unique id to identify resources created by the test session. In this way we will avoid test failures due to resource collisions.
2. Running cluster and image tests separately. This is handy because we expect the cluster test to succeed and the image test to fail due to known issue in cloudformation.
3. Running tests with only a single combination of Go and Terraform version (overkilling to do more than one)
4. Minor changes to workflow step titles

### Tests
* Describe the automated and/or manual tests executed to validate the PR.
* Describe the added/modified tests, if any.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
5. I have made the PR point to **the right branch**.
6. I have added the right labels to the PR.
7. I have checked that all commits' messages are clear, describing what and why vs how.
8. I have successfully executed lint and tests to prove the quality and correctness of the change.
9. I have added tests to validate the proposed change.
10. I have added the documentation to describe my changes (if appropriate).
11. I have added the necessary entries to the changelog (if appropriate).
12. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
