### PR TITLE
[Workflows] Add possibility to manually run e2e tests on a target ref.

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -8,6 +8,14 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          ref: the branch, tag or SHA to checkout.
+          If empty, the ref is inferred from the event that triggered the workflow.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   id-token: write
@@ -26,6 +34,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup Go ${{ matrix.go }}
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
### Description of changes
Add possibility to manually run e2e tests on a target ref.

### Tests
* Tested in forked repo that the e2e test action can be manually triggered targeting a specific commit id. https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/9189831797/job/25272719351
* Tested in forked repo that the e2e test action can be manually triggered omitting the commit id and in that case the id is determined by the workflow context (default behaviour)
* https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/9189884772/job/25272889624
* Tested in forked repo that the e2e test action can be triggered by pushes on the event commit id
https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/9189814895

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
