### PR TITLE
[Test] Use a unique test id to the e2e tests launched locally.

### DIFF
--- a/tools/tests/test-env.sh
+++ b/tools/tests/test-env.sh
@@ -18,6 +18,12 @@
 #                                 If true, the tests will use the user role ParallelClusterApiUserRole returned by the ParallelCluster API.
 #                                 Default is false.
 #
+# TEST_ID:                        [Id];
+#                                 This is the ID that is used to identify the test run.
+#                                 This is used to create unique names for resources and
+#                                 it's appended as suffix to the name of the cluster and AMI.
+#                                 Default is a timestamp in the format YYYYmmdd-HHMMSS.
+#
 # TEST_CLUSTER_NAME:              [Cluster name];
 #                                 This is the name of the cluster that tests will create.
 #                                 Default is test-cluster.
@@ -30,5 +36,6 @@ export TEST_REGION="us-east-1"
 export TEST_AVAILABILITY_ZONE="us-east-1a"
 export TEST_PCAPI_STACK_NAME="ParallelCluster"
 export TEST_USE_USER_ROLE="true"
-export TEST_CLUSTER_NAME="test-cluster-$(whoami)"
-export TEST_IMAGE_NAME="test-image-$(whoami)"
+export TEST_ID=$(date +'%Y%m%d-%H%M%S-%s')
+export TEST_CLUSTER_NAME="test-cluster-$(whoami)-$TEST_ID"
+export TEST_IMAGE_NAME="test-image-$(whoami)-$TEST_ID"


### PR DESCRIPTION
### Description of changes
Use a unique test id to the e2e tests launched locally.

### Tests
Used to launch e2e test from local environment. Verified that cluster/image stacks created by integ test have the unique id as suffix.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
