### PR TITLE
[Bugfix] Fix validator suppression

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,3 +147,25 @@ go install -v github.com/google/go-licenses@latest
 ```
 go-licenses report . --template tools/licensing/go-licenses.tpl > THIRD-PARTY-LICENSES.txt 2> /tmp/go-licenses-errors.txt
 ```
+
+
+## Logging
+Enable logging by setting envars:
+```
+export TF_LOG_PATH="tf.log"
+export TF_LOG="TRACE"
+export TF_LOG_PROVIDER="TRACE"
+```
+
+Execute the provider in debug mode by setting `Debug: true` in `internal/provider/openapi/configuration.go`:
+
+```
+func NewConfiguration() *Configuration {
+	cfg := &Configuration{
+	    ...
+		Debug:            true,
+		...
+	}
+	return cfg
+}
+```

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -379,7 +380,7 @@ func (r *ClusterResource) Create(
 
 	suppressValidators := make([]string, 0)
 	for _, s := range data.SuppressValidators.Elements() {
-		suppressValidators = append(suppressValidators, s.String())
+		suppressValidators = append(suppressValidators, strings.ReplaceAll(s.String(), `"`, ``))
 	}
 
 	tflog.Info(ctx, "Creating Parallel Cluster")

--- a/internal/provider/files/cluster_test/pcluster.tf
+++ b/internal/provider/files/cluster_test/pcluster.tf
@@ -72,7 +72,10 @@ locals {
 resource "pcluster_cluster" "test" {
   cluster_name        = var.cluster_name
   region              = var.region
-  suppress_validators = []
+  validation_failure_level = "WARNING"
+  suppress_validators = [
+    "type:KeyPairValidator"
+  ]
 
   cluster_configuration = yamlencode(local.test_config)
 


### PR DESCRIPTION
### Description of changes
Fixed validator suppression. In particular:
1. Remove double quotes around suppressValidator items to prevent formatting issues when values are passed to the API.
2. Adapt existing test to make use of validators suppression
3. Add instructions to enable logging (used to investigate the issue)

Before this change the terraform apply used to fail with the below error:

```
│ Error: 400 Bad Request
│ 
│   with module.pcluster.module.clusters[0].pcluster_cluster.managed_configs["ExampleClusterOnly01"],
│   on ../../modules/clusters/main.tf line 35, in resource "pcluster_cluster" "managed_configs":
│   35: resource "pcluster_cluster" "managed_configs" {
│ 
│ {{"message":"Bad Request: '\"ALL\"' does not match '^(ALL|type:[A-Za-z0-9]+)$'"}
│ }
╵
```

### Tests
1. cluster e2e test succeeded

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
5. I have made the PR point to **the right branch**.
6. I have added the right labels to the PR.
7. I have checked that all commits' messages are clear, describing what and why vs how.
8. I have successfully executed lint and tests to prove the quality and correctness of the change.
9. I have added tests to validate the proposed change.
10. I have added the documentation to describe my changes (if appropriate).
11. I have added the necessary entries to the changelog (if appropriate).
12. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
