### PR TITLE
[BugFix] Support validator suppression in cluster update and fix cluster e2e test when suppressing validators

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -515,6 +515,11 @@ func (r *ClusterResource) Update(
 		)
 	}
 
+	suppressValidators := make([]string, 0)
+	for _, s := range planData.SuppressValidators.Elements() {
+		suppressValidators = append(suppressValidators, strings.ReplaceAll(s.String(), `"`, ``))
+	}
+
 	// If the cluster config and region are unchanged nothing is left to do.
 	if planData.ClusterConfiguration == stateData.ClusterConfiguration {
 		if planData.Region.Equal(stateData.Region) {
@@ -539,7 +544,9 @@ func (r *ClusterResource) Update(
 		}
 	}
 
-	content, fullResp, err := clusterUpdateRequest.Execute()
+	content, fullResp, err := clusterUpdateRequest.
+		SuppressValidators(suppressValidators).
+		Execute()
 	if err != nil || content == nil {
 		if fullResp != nil {
 			resp.Diagnostics.AddError("Failure while updating cluster.",

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -158,9 +158,9 @@ func TestUnitClusterResource(t *testing.T) {
 			"rollback_on_failure":   {},
 			"suppress_validators": tftypes.NewValue(
 				tftypes.List{ElementType: tftypes.String},
-				[]tftypes.Value{},
+				[]tftypes.Value{tftypes.NewValue(tftypes.String, "type:some_validator")},
 			),
-			"validation_failure_level": {},
+			"validation_failure_level": tftypes.NewValue(tftypes.String, "some_level"),
 			"id":                       tftypes.NewValue(tftypes.String, "some_name"),
 			"cloudformation_stack_arn": tftypes.NewValue(tftypes.String, "some_arn"),
 			"cloudformation_stack_status": tftypes.NewValue(
@@ -260,7 +260,8 @@ func TestUnitClusterResource(t *testing.T) {
 		CloudformationStackStatus: types.StringValue(string(input.CloudFormationStackStatus)),
 		Region:                    types.StringValue(input.Region),
 		RollbackOnFailure:         types.BoolNull(),
-		SuppressValidators:        types.ListValueMust(types.StringType, []attr.Value{}),
+		SuppressValidators:        types.ListValueMust(types.StringType, []attr.Value{types.StringValue("type:some_validator")}),
+		ValidationFailureLevel:    types.StringValue("some_level"),
 		Version:                   types.StringValue(input.Version),
 	}
 
@@ -464,6 +465,7 @@ func TestUnitClusterResource(t *testing.T) {
 	}
 
 	expectedOutput.SuppressValidators = types.ListNull(types.StringType)
+	expectedOutput.ValidationFailureLevel = types.StringNull()
 	if !reflect.DeepEqual(output, expectedOutput) {
 		t.Fatalf(
 			"Expected output did not match actual output: \nO: %v\nE: %v\n",

--- a/internal/provider/cluster_test.go
+++ b/internal/provider/cluster_test.go
@@ -128,6 +128,7 @@ func TestEnd2EndCluster(t *testing.T) {
 				ResourceName:             "pcluster_cluster." + testResourceName,
 				ImportState:              true,
 				ImportStateVerify:        true,
+				ImportStateVerifyIgnore:  []string{"suppress_validators", "validation_failure_level"},
 			},
 			{
 				// Update and Read testing


### PR DESCRIPTION
### Description of changes
The provider was missing the support for validator suppression on cluster update.
With this PR we are adding this support.
Also, we fixed the cluster e2e test by ignoring suppress_validator and validation_failure_level fields in the import state as they are not meant to be part of the imported state. The e2e test started failing when we introduced the use of these fields in the test.


### Tests
* E2E test succeeded: https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/9414012980

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
