### PR TITLE
[Docs] Fix cross-compatibility matrix by declaring that provider 1.0.0 is compatible with PC versions 3.8.0-3.10.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The following matrix describes the compatibility between the provider and the Pa
 
 | Provider version | ParallelCluster version |
 |------------------|-------------------------|
-| 1.0.0            | 3.8.0+                  |
+| 1.0.0            | 3.8.0-3.10.1            |
 
 ## Issues
 


### PR DESCRIPTION
### Description of changes
Fix cross-compatibility matrix by declaring that provider 1.0.0 is compatible with PC versions 3.8.0-3.10.1.
PC 3.11.0 introduced a change in PCAPI that will be reflected in the next release of the provider.
Related issue https://github.com/aws/aws-parallelcluster/issues/6489

### Tests
Verified that provider 1.0.0 is compatible with PC 3.10.1, but it's not with PC 3.11.0 and 3.11.1.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
