### PR TITLE
[Tests] Make E2E test use the new ParallelCluster API 3.11.1.

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -58,7 +58,7 @@ jobs:
           TF_ACC: "1"
           TEST_REGION: "us-east-1"
           TEST_AVAILABILITY_ZONE: "us-east-1a"
-          TEST_PCAPI_STACK_NAME: "ParallelCluster"
+          TEST_PCAPI_STACK_NAME: "ParallelClusterAPI"
           TEST_USE_USER_ROLE: "true"
           TEST_CLUSTER_NAME: "test-cluster-github-${{ env.TEST_ID }}"
           TEST_IMAGE_NAME: "test-image-github-${{ env.TEST_ID }}"


### PR DESCRIPTION
### Description of changes
Make E2E test use the new ParallelCluster API 3.11.1.
The PCAPI stack was manually deployed in the target account using the terraform module, that use `ParallelClusterAPI` as default PCAPI stack name.

### Tests
* E2E test succeeded: https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/12066757890

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
