### PR TITLE
[Tests] Use login nodes in e2e tests.

### DIFF
--- a/internal/provider/files/cluster_test/pcluster.tf
+++ b/internal/provider/files/cluster_test/pcluster.tf
@@ -66,6 +66,26 @@ locals {
         QueueUpdateStrategy = "TERMINATE"
       }
     }
+    LoginNodes : {
+      Pools : [
+        {
+          Name : "login1"
+          InstanceType : "t3.small"
+          Count : 1
+          Networking : {
+            SubnetIds : [var.subnet != null ? var.subnet : aws_default_subnet.public_az1.id]
+          },
+          Iam : {
+            AdditionalIamPolicies : [
+              {
+                Policy : "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+              }
+            ]
+          },
+          GracetimePeriod : 3
+        }
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
### Description of changes
Use login nodes in e2e tests.
This change is required to exercise the fix shipped in the next upcoming release of the provider (1.1.0)

### Tests
* SUCCEEDED https://github.com/gmarciani/terraform-provider-aws-parallelcluster/actions/runs/12069677563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
